### PR TITLE
Revised models to use integers and added session model

### DIFF
--- a/server/db/models/Order.js
+++ b/server/db/models/Order.js
@@ -5,9 +5,9 @@ const Order = db.define('order', {
   status: {
     type: Sequelize.ENUM('Created', 'Processing', 'Cancelled', 'Completed')
   },
-  sessionId: {
-    type: Sequelize.INTEGER
-  },
+  // sessionId: {
+  //   type: Sequelize.INTEGER
+  // },
   subtotal: {
     type: Sequelize.INTEGER
   }

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -3,6 +3,7 @@ const Order = require('./Order')
 const Product = require('./Product')
 const Review = require('./review')
 const ProductOrder = require('./product_order')
+const Session = require('./session')
 
 /**
  * If we had any associations to make, this would be a great place to put them!
@@ -31,5 +32,6 @@ module.exports = {
   Order,
   Product,
   Review,
-  ProductOrder
+  ProductOrder,
+  Session
 }

--- a/server/db/models/index.js
+++ b/server/db/models/index.js
@@ -21,6 +21,9 @@ Product.hasMany(Review)
 
 Product.belongsToMany(Order, {through: ProductOrder})
 Order.belongsToMany(Product, {through: ProductOrder})
+
+Order.belongsTo(Session, {foreignKey: 'sid'})
+
 /**
  * We'll export all of our models here, so that any time a module needs a model,
  * we can just require it from 'db/models'

--- a/server/db/models/product.js
+++ b/server/db/models/product.js
@@ -17,10 +17,10 @@ const Product = db.define('product', {
     }
   },
   price: {
-    type: Sequelize.DECIMAL(10, 2),
+    type: Sequelize.INTEGER,
     allowNull: false,
     validate: {
-      isDecimal: true
+      isInt: true
     }
   },
   quantity: {

--- a/server/db/models/product_order.js
+++ b/server/db/models/product_order.js
@@ -3,7 +3,10 @@ const db = require('../db')
 
 const ProductOrder = db.define('product_Order', {
   price: {
-    type: Sequelize.DECIMAL(10, 2)
+    type: Sequelize.INTEGER,
+    validate: {
+      isInt: true
+    }
   },
   quantity: {
     type: Sequelize.INTEGER

--- a/server/db/models/session.js
+++ b/server/db/models/session.js
@@ -2,7 +2,7 @@ const Sequelize = require('sequelize')
 const db = require('../db')
 
 //replicate the table created by connect-session-sequelize
-const Session = db.define('session', {
+const Session = db.define('Session', {
   sid: {
     type: Sequelize.STRING,
     primaryKey: true

--- a/server/db/models/session.js
+++ b/server/db/models/session.js
@@ -1,0 +1,14 @@
+const Sequelize = require('sequelize')
+const db = require('../db')
+
+//replicate the table created by connect-session-sequelize
+const Session = db.define('session', {
+  sid: {
+    type: Sequelize.STRING,
+    primaryKey: true
+  },
+  expires: Sequelize.DATE,
+  data: Sequelize.STRING(50000)
+})
+
+module.exports = Session

--- a/server/db/models/user.js
+++ b/server/db/models/user.js
@@ -31,7 +31,8 @@ const User = db.define('user', {
     type: Sequelize.STRING
   },
   isAdmin: {
-    type: Sequelize.BOOLEAN
+    type: Sequelize.BOOLEAN,
+    defaultValue: false
   }
 })
 


### PR DESCRIPTION
Fixes #6 .  No rush on reviewing this but I wanted to open the pull request tonight in case it helps anyone who might be working with the models.  It looks like there may be merge conflicts so I'm ok if we wait until class to do that but feel free to take a peek and review if you like.  The session table that previously existed was made with the module connect-session-sequelize so I referenced their documentation when re-creating it.  Order should now have sid as a foreign key for session instead of sessionId.  Unfortunately it doesn't seem like we can rename sid but it will be easy enough to get used to.