### PR TITLE
removes bug on inital request w/out a session where 2 orders with sta…

### DIFF
--- a/server/helper/index.js
+++ b/server/helper/index.js
@@ -1,14 +1,18 @@
 const {Order} = require('../db/models')
 
 const findSessionCart = async reqSid => {
-  const order = await Order.findOne({
-    where: {
-      sid: reqSid,
-      status: 'Created'
-    },
-    include: [{all: true}]
-  })
-  return order
+  try {
+    const order = await Order.findOne({
+      where: {
+        sid: reqSid,
+        status: 'Created'
+      },
+      include: [{all: true}]
+    })
+    return order
+  } catch (err) {
+    console.error('error in findsessioncart in helper/index.js', err)
+  }
 }
 
 const cancelCart = async reqSid => {


### PR DESCRIPTION
…tus of "Created" were created for the sessionID

### Assignee Tasks

fixes a bug in session-cart persistence where 2 orders with status: "Created" were created - as well as a bug which threw sequelize errors when a new session was created and the cart middleware ran and would try to create an Order table with sid  (which is a FK on Order, PK on Session)... Session table hadn't yet created a record with the sid , so when trying to use the sid to create an order it threw an error because of the association. 

Fix was to manually create the record in Session with sid: req.sessionID - throws no errors and only creates 1 cart, removing 2 bugs

### Guidelines

Please add a description of this Pull Request's motivation, scope, outstanding issues or potential alternatives, reasoning behind the current solution, and any other relevant information for posterity.

---

_Your PR Notes Here_
